### PR TITLE
Feature/simplify credentials

### DIFF
--- a/src/Insperex.EventHorizon.EventStreaming.Pulsar/Extensions/PulsarOAuth2ConfigExtensions.cs
+++ b/src/Insperex.EventHorizon.EventStreaming.Pulsar/Extensions/PulsarOAuth2ConfigExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Text;
+using Newtonsoft.Json;
+using Insperex.EventHorizon.EventStreaming.Pulsar.Models;
+
+namespace Insperex.EventHorizon.EventStreaming.Pulsar.Extensions;
+
+public static class PulsarOAuth2ConfigExtensions
+{
+    public static PulsarOAuth2Config FromBase64EncodedUri(Uri uri)
+    {
+        var parts = uri.ToString().Split(',');
+        if (parts.Length != 2)
+            throw new ArgumentException("Invalid base64 encoded uri");
+
+        return JsonConvert.DeserializeObject<PulsarOAuth2Config>(
+            Encoding.UTF8.GetString(Convert.FromBase64String(parts[1])));
+    }
+
+    public static Uri ToBase64EncodedUri(this PulsarOAuth2Config config)
+    {
+        var json = JsonConvert.SerializeObject(config);
+        var bytes = Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
+        return new Uri($"data:application/json;base64,{bytes}");
+    }
+}
+

--- a/src/Insperex.EventHorizon.EventStreaming.Pulsar/Models/PulsarConfig.cs
+++ b/src/Insperex.EventHorizon.EventStreaming.Pulsar/Models/PulsarConfig.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace Insperex.EventHorizon.EventStreaming.Pulsar.Models;
 
@@ -27,12 +27,12 @@ public class PulsarOAuth2Config
     [JsonProperty("issuer_url")]
     public string IssuerUrl { get; set; }
 
-    [JsonIgnore]
+    [JsonProperty("audience")]
     public string Audience { get; set; }
 
-    [JsonIgnore]
+    [JsonProperty("token_address")]
     public string TokenAddress { get; set; }
 
-    [JsonIgnore]
+    [JsonProperty("grant_type")]
     public string GrantType { get; set; }
 }

--- a/src/Insperex.EventHorizon.EventStreaming.Pulsar/PulsarClientResolver.cs
+++ b/src/Insperex.EventHorizon.EventStreaming.Pulsar/PulsarClientResolver.cs
@@ -1,117 +1,112 @@
 using System;
-using System.IO;
-using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using IdentityModel.Client;
+using Insperex.EventHorizon.EventStreaming.Pulsar.Extensions;
 using Insperex.EventHorizon.EventStreaming.Pulsar.Models;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
 using Pulsar.Client.Api;
 using SharpPulsar.Admin.v2;
 
-namespace Insperex.EventHorizon.EventStreaming.Pulsar
+namespace Insperex.EventHorizon.EventStreaming.Pulsar;
+
+public class PulsarClientResolver : IDisposable
 {
-    public class PulsarClientResolver : IDisposable
+    private IOptions<PulsarConfig> _options;
+    private PulsarAdminRESTAPIClient _admin;
+    private PulsarClient _client;
+    private Uri _credentials;
+    private bool disposed;
+
+    public PulsarClientResolver(IOptions<PulsarConfig> options)
     {
-        private readonly IOptions<PulsarConfig> _options;
-        private PulsarAdminRESTAPIClient _admin;
-        private PulsarClient _client;
-        private readonly Uri _fileUri;
-        private readonly string _fileName;
+        _options = options;
+        _credentials = _options.Value.OAuth2.ToBase64EncodedUri();
+    }
 
-        public PulsarClientResolver(IOptions<PulsarConfig> options)
+    public async Task<PulsarClient> GetPulsarClientAsync()
+    {
+        if (_client != null)
+            return _client;
+
+        var builder = new PulsarClientBuilder()
+            .ServiceUrl(_options.Value.ServiceUrl)
+            .EnableTransaction(true);
+
+        if (_options.Value.OAuth2 != null)
         {
-            _options = options;
-
-            // Create File for pulsar client
-            _fileName = $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}oauth2.txt";
-            var json = JsonConvert.SerializeObject(_options.Value.OAuth2);
-
-            if(!File.Exists(_fileName))
-                File.WriteAllText(_fileName, json);
-
-            _fileUri = new Uri(_fileName);
+            var audience = _options.Value.OAuth2.Audience;
+            builder = builder.Authentication(AuthenticationFactoryOAuth2.ClientCredentials(new Uri(_options.Value.OAuth2.IssuerUrl), audience, _credentials));
         }
 
-        public async Task<PulsarClient> GetPulsarClientAsync()
+        return await builder.BuildAsync();
+    }
+
+    public async Task<IPulsarAdminRESTAPIClient> GetAdminClientAsync()
+    {
+        if (_admin != null) return _admin;
+
+        var client = new HttpClient
         {
-            if (_client != null)
-                return _client;
+            BaseAddress = new Uri($"{_options.Value.AdminUrl}/admin/v2/")
+        };
 
-            var builder = new PulsarClientBuilder()
-                .ServiceUrl(_options.Value.ServiceUrl)
-                .EnableTransaction(true);
+        if (_options.Value.OAuth2 != null)
+        {
+            var token = await GetTokenAsync(_options.Value.OAuth2);
+            client.SetBearerToken(token);
+        }
 
-            if (_options.Value.OAuth2 != null)
+        return _admin = new PulsarAdminRESTAPIClient(client);
+    }
+
+    public HttpClient GetAdminHttpClient()
+    {
+        return new HttpClient { BaseAddress = new Uri($"{_options.Value.AdminUrl}/admin/v2/") };
+    }
+
+    private static async Task<string> GetTokenAsync(PulsarOAuth2Config config)
+    {
+        var request = new TokenRequest
+        {
+            Address = config.TokenAddress,
+            GrantType = config.GrantType,
+            ClientId = config.ClientId,
+            ClientSecret = config.ClientSecret,
+            ClientCredentialStyle = ClientCredentialStyle.PostBody,
+        };
+        request.Parameters.Add("audience", config.Audience);
+        request.Parameters.Add("type", config.Type);
+        request.Parameters.Add("client_email", config.ClientEmail);
+        request.Parameters.Add("issuer_url", config.IssuerUrl);
+
+        // Get Token
+        var client = new HttpClient();
+        var response = await client.RequestTokenAsync(request);
+        return response.AccessToken;
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposed)
+        {
+            if (disposing)
             {
-                var audience = _options.Value.OAuth2.Audience;
-                builder = builder.Authentication(AuthenticationFactoryOAuth2.ClientCredentials(new Uri(_options.Value.OAuth2.IssuerUrl), audience, _fileUri));
+                _client.CloseAsync();
             }
 
-            return await builder.BuildAsync();
-        }
+            // Large fields to null;
+            _options = null;
+            _admin = null;
+            _credentials = null;
 
-        public async Task<IPulsarAdminRESTAPIClient> GetAdminClientAsync()
-        {
-            if (_admin != null) return _admin;
-
-            var client = new HttpClient
-            {
-                BaseAddress = new Uri($"{_options.Value.AdminUrl}/admin/v2/")
-            };
-
-            if (_options.Value.OAuth2 != null)
-            {
-                var oauth2 = _options.Value.OAuth2;
-                var token = await GetTokenAsync(oauth2.TokenAddress, oauth2.GrantType, oauth2.Audience, _fileUri);
-                client.SetBearerToken(token);
-            }
-
-            return _admin = new PulsarAdminRESTAPIClient(client);
-        }
-
-        public HttpClient GetAdminHttpClient()
-        {
-            return new HttpClient {BaseAddress = new Uri($"{_options.Value.AdminUrl}/admin/v2/")};
-        }
-
-        private static async Task<PulsarOAuthData> ReadOAuth2File(Uri fileUri)
-        {
-            // Load Json
-            var webRequest = WebRequest.Create(fileUri);
-            webRequest.Credentials = CredentialCache.DefaultCredentials;
-            webRequest.Method ="GET";
-            var webResponse = await webRequest.GetResponseAsync();
-            var contents = await new StreamReader(webResponse.GetResponseStream()).ReadToEndAsync();
-            return JsonConvert.DeserializeObject<PulsarOAuthData>(contents);
-        }
-
-        private static async Task<string> GetTokenAsync(string tokenAddress, string grantType, string audience, Uri fileUri)
-        {
-            var json = await ReadOAuth2File(fileUri);
-            var request = new TokenRequest
-            {
-                Address = tokenAddress,
-                GrantType = grantType,
-                ClientId = json.ClientId,
-                ClientSecret = json.ClientSecret,
-                ClientCredentialStyle = ClientCredentialStyle.PostBody,
-            };
-            request.Parameters.Add("audience", audience);
-            request.Parameters.Add("type", json.Type);
-            request.Parameters.Add("client_email", json.ClientEmail);
-            request.Parameters.Add("issuer_url", json.IssuerUrl);
-
-            // Get Token
-            var client = new HttpClient();
-            var response = await client.RequestTokenAsync(request);
-            return response.AccessToken;
-        }
-
-        public void Dispose()
-        {
-            File.Delete(_fileName);
+            disposed = true;
         }
     }
 }

--- a/src/Insperex.EventHorizon.EventStreaming/Insperex.EventHorizon.EventStreaming.csproj
+++ b/src/Insperex.EventHorizon.EventStreaming/Insperex.EventHorizon.EventStreaming.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Insperex.EventHorizon.EventStreaming.Test/Unit/Pulsar/PulsarOAuth2ConfigExtensionsUnitTest.cs
+++ b/test/Insperex.EventHorizon.EventStreaming.Test/Unit/Pulsar/PulsarOAuth2ConfigExtensionsUnitTest.cs
@@ -1,0 +1,66 @@
+using Insperex.EventHorizon.EventStreaming.Pulsar.Extensions;
+using Insperex.EventHorizon.EventStreaming.Pulsar.Models;
+using Xunit;
+
+namespace Insperex.EventHorizon.EventStreaming.Test.Unit.Pulsar;
+
+[Trait("Category", "Unit")]
+public class PulsarOAuth2ConfigExtensionsUnitTest
+{
+    [Fact]
+    public void ToBase64EncodedUri()
+    {
+        // Arrange
+        var config = new PulsarOAuth2Config
+        {
+            Type = "type",
+            ClientId = "client_id",
+            ClientSecret = "client_secret",
+            ClientEmail = "client_email",
+            IssuerUrl = "issuer_url",
+            TokenAddress = "token_address",
+            GrantType = "grant_type",
+            Audience = "audience"
+        };
+
+        // Act
+        var result = config.ToBase64EncodedUri();
+
+        // Assert
+        Assert.StartsWith("data:application/json;base64,", result.ToString());
+        Assert.Equal("data", result.Scheme);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void FromBase64EncodedUri()
+    {
+        // Arrange
+        var config = new PulsarOAuth2Config
+        {
+            Type = "type",
+            ClientId = "client_id",
+            ClientSecret = "client_secret",
+            ClientEmail = "client_email",
+            IssuerUrl = "issuer_url",
+            TokenAddress = "token_address",
+            GrantType = "grant_type",
+            Audience = "audience"
+        };
+        var uri = config.ToBase64EncodedUri();
+
+        // Act
+        var result = PulsarOAuth2ConfigExtensions.FromBase64EncodedUri(uri);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(config.Type, result.Type);
+        Assert.Equal(config.ClientId, result.ClientId);
+        Assert.Equal(config.ClientSecret, result.ClientSecret);
+        Assert.Equal(config.ClientEmail, result.ClientEmail);
+        Assert.Equal(config.IssuerUrl, result.IssuerUrl);
+        Assert.Equal(config.TokenAddress, result.TokenAddress);
+        Assert.Equal(config.GrantType, result.GrantType);
+        Assert.Equal(config.Audience, result.Audience);
+    }
+}


### PR DESCRIPTION
The Pulsar F# library takes credentials from a Uri. The library however can handle two types of Uri Schemes:

File: This tells the F# library to load a file from a given Uri.
Data: This tells the F# library that the Uri is actually a Base64 encoded JSON configuration object
EventHorizons originally used File. This PR changes that to use Data.

The original File implementation had a number of flaws that were painful:

We created an oauth2.txt file everytime the PulsarClientResolver was called; this incurred IO
We deleted the file on dispose, that created multi-threading conflicts in several places
The code was much more complex to handle this

Also accidentally got your Dotnet 8 Changes in here.